### PR TITLE
Fix a typo

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,7 +29,7 @@ git clone https://github.com/barrucadu/dejafu.git
 cd search-party
 cabal sandbox init
 cabal sandbox add-source ../dejafu
-cabal install --only-dependenciesa
+cabal install --only-dependencies
 cabal build
 ~~~~
 


### PR DESCRIPTION
I don't speak Haskell >.<, but I think it's meant to be "--only-dependencies" in the build manual...
